### PR TITLE
Fix UDP client broken on newer versions of InfluxDB.

### DIFF
--- a/influxdb.hpp
+++ b/influxdb.hpp
@@ -87,7 +87,7 @@ namespace influxdb_cpp {
             _escape(v, "\"");
             lines_ << '\"';
             return (detail::field_caller&)*this;
-        }    
+        }
         detail::field_caller& _f_i(char delim, const std::string& k, long long v) {
             lines_ << delim;
             _escape(k, ",= ");
@@ -122,9 +122,10 @@ namespace influxdb_cpp {
             addr.sin_family = AF_INET;
             addr.sin_port = htons(port);
             if((addr.sin_addr.s_addr = inet_addr(host.c_str())) == INADDR_NONE) return -1;
-            
+
             if((sock = socket(AF_INET, SOCK_DGRAM, 0)) < 0) return -2;
 
+            lines_ << '\n';
             if(sendto(sock, &lines_.str()[0], lines_.str().length(), 0, (struct sockaddr *)&addr, sizeof(addr)) < (int)lines_.str().length())
                 ret = -3;
 
@@ -143,7 +144,7 @@ namespace influxdb_cpp {
 
         std::stringstream lines_;
     };
-    
+
     namespace detail {
         struct tag_caller : public builder {
             detail::tag_caller& tag(const std::string& k, const std::string& v)       { return _t(k, v); }


### PR DESCRIPTION
I'm not sure if the client ever worked on older versions, but for
the version I'm running, 1.7.1-1, the UDP client MUST terminate its
request with a newline. Otherwise, the request will fail.

The relevant comment in the official InfluxDB source is here
https://github.com/influxdata/influxdb/blob/6270a58b3f7c2fd7eb1543c5575a01c54c4e9bd1/client/v2/udp.go#L90

Looks like my editor removed trailing whitespaces on each line - apologies
for the excess modifications, but the only relevant one is at L128.