### PR TITLE
Added missing Linux header (sys/uio.h)

### DIFF
--- a/influxdb.hpp
+++ b/influxdb.hpp
@@ -24,6 +24,7 @@
     #include <unistd.h>
     #include <sys/types.h>
     #include <sys/socket.h>
+    #include <sys/uio.h>
     #include <netinet/in.h>
     #include <arpa/inet.h>
     #define closesocket close


### PR DESCRIPTION
<sys/uio.h> is required under at least with Ubuntu 18.04 as it declares "writev"