### PR TITLE
Precision now sets the number of decimals

### DIFF
--- a/influxdb.hpp
+++ b/influxdb.hpp
@@ -101,6 +101,7 @@ namespace influxdb_cpp {
             lines_ << delim;
             _escape(k, ",= ");
             lines_.precision(prec);
+            lines_.setf(std::ios::fixed);
             lines_ << '=' << v;
             return (detail::field_caller&)*this;
         }


### PR DESCRIPTION
Dear Orca,

Thank you so much for this client!

I fixed the 3rd parameter `precision` of `field()` so it indicates the number of decimals instead of the total number of digits. Now it should behave like your influxdb-c client.

Yours,
Trucosuso.